### PR TITLE
Add make_XString_from_string() and make_XStringSet_from_strings()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -3,7 +3,7 @@ Title: Efficient manipulation of biological strings
 Description: Memory efficient string containers, string matching
 	algorithms, and other utilities, for fast manipulation of large
 	biological sequences or sets of sequences.
-Version: 2.51.2
+Version: 2.51.3
 Encoding: UTF-8
 Author: H. Pagès, P. Aboyoun, R. Gentleman, and S. DebRoy
 Maintainer: H. Pagès <hpages@fredhutch.org>

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -60,9 +60,11 @@ export(
     seqtype, "seqtype<-", get_seqtype_conversion_lookup, alphabet,
 
     ## XString-class.R:
+    make_XString_from_string,
     BString, DNAString, RNAString, AAString,
 
     ## XStringSet-class.R:
+    make_XStringSet_from_strings,
     BStringSet, DNAStringSet, RNAStringSet, AAStringSet,
 
     ## MaskedXString-class.R:

--- a/man/Biostrings-internals.Rd
+++ b/man/Biostrings-internals.Rd
@@ -23,6 +23,13 @@
 \alias{seqtype<-}
 \alias{get_seqtype_conversion_lookup}
 
+% XString-class.R:
+\alias{make_XString_from_string}
+\alias{make_XString_from_string,XString-method}
+
+% XStringSet-class.R:
+\alias{make_XStringSet_from_strings}
+\alias{make_XStringSet_from_strings,XStringSet-method}
 
 \title{Biostrings internals}
 


### PR DESCRIPTION
These are low-level generics called by the XString() and XStringSet()
constructors, respectively. They are not intended to be used directly
by the end user. Their purpose is to make it easy to extend the XString()
and XStringSet() constructors to support XString and XStringSet
derivatives defined in other packages.